### PR TITLE
change int into uint8_t, along with some others

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <cmath>
 
@@ -349,32 +349,32 @@ class scanMerger : public rclcpp::Node
     }
     void initialize_params(){
         
-        this->declare_parameter("pointCloudTopic");
-        this->declare_parameter("pointCloutFrameId");
+        this->declare_parameter("pointCloudTopic","base/custom_cloud");
+        this->declare_parameter("pointCloutFrameId","laser");
 
-        this->declare_parameter("scanTopic1");
-        this->declare_parameter("laser1XOff");
-        this->declare_parameter("laser1YOff");
-        this->declare_parameter("laser1ZOff");
-        this->declare_parameter("laser1Alpha");
-        this->declare_parameter("laser1AngleMin");
-        this->declare_parameter("laser1AngleMax");
-        this->declare_parameter("laser1R");
-        this->declare_parameter("laser1G");
-        this->declare_parameter("laser1B");
-        this->declare_parameter("show1");
+        this->declare_parameter("scanTopic1","lidar_front_right/scan");
+        this->declare_parameter("laser1XOff",-0.45);
+        this->declare_parameter("laser1YOff",0.24);
+        this->declare_parameter("laser1ZOff",0.0);
+        this->declare_parameter("laser1Alpha",45.0);
+        this->declare_parameter("laser1AngleMin",-181.0);
+        this->declare_parameter("laser1AngleMax",181.0);
+        this->declare_parameter("laser1R",255);
+        this->declare_parameter("laser1G",0);
+        this->declare_parameter("laser1B",0);
+        this->declare_parameter("show1",true);
 
-        this->declare_parameter("scanTopic2");
-        this->declare_parameter("laser2XOff");
-        this->declare_parameter("laser2YOff");
-        this->declare_parameter("laser2ZOff");
-        this->declare_parameter("laser2Alpha");
-        this->declare_parameter("laser2AngleMin");
-        this->declare_parameter("laser2AngleMax");
-        this->declare_parameter("laser2R");
-        this->declare_parameter("laser2G");
-        this->declare_parameter("laser2B");
-        this->declare_parameter("show2");
+        this->declare_parameter("scanTopic2","lidar_rear_left/scan");
+        this->declare_parameter("laser2XOff",0.315);
+        this->declare_parameter("laser2YOff",-0.24);
+        this->declare_parameter("laser2ZOff",0.0);
+        this->declare_parameter("laser2Alpha",225.0);
+        this->declare_parameter("laser2AngleMin",-181.0);
+        this->declare_parameter("laser2AngleMax",181.0);
+        this->declare_parameter("laser2R",0);
+        this->declare_parameter("laser2G",0);
+        this->declare_parameter("laser2B",255);
+        this->declare_parameter("show2",true);
 
     }
     void refresh_params(){
@@ -387,9 +387,9 @@ class scanMerger : public rclcpp::Node
         this->get_parameter_or<float>("laser1Alpha",laser1Alpha_, 0.0);
         this->get_parameter_or<float>("laser1AngleMin",laser1AngleMin_, -181.0);
         this->get_parameter_or<float>("laser1AngleMax",laser1AngleMax_, 181.0);
-        this->get_parameter_or<int>("laser1R",laser1R_, 0);
-        this->get_parameter_or<int>("laser1G",laser1G_, 0);
-        this->get_parameter_or<int>("laser1B",laser1B_, 0);
+        this->get_parameter_or<uint8_t>("laser1R",laser1R_, 0);
+        this->get_parameter_or<uint8_t>("laser1G",laser1G_, 0);
+        this->get_parameter_or<uint8_t>("laser1B",laser1B_, 0);
         this->get_parameter_or<bool>("show1",show1_, true);
         this->get_parameter_or<std::string>("scanTopic2",topic2_, "lidar_rear_left/scan");
         this->get_parameter_or<float>("laser2XOff",laser2XOff_, 0.0);
@@ -398,9 +398,9 @@ class scanMerger : public rclcpp::Node
         this->get_parameter_or<float>("laser2Alpha",laser2Alpha_, 0.0);
         this->get_parameter_or<float>("laser2AngleMin",laser2AngleMin_,-181.0);
         this->get_parameter_or<float>("laser2AngleMax",laser2AngleMax_, 181.0);
-        this->get_parameter_or<int>("laser2R",laser2R_, 0);
-        this->get_parameter_or<int>("laser2G",laser2G_, 0);
-        this->get_parameter_or<int>("laser2B",laser2B_, 0);
+        this->get_parameter_or<uint8_t>("laser2R",laser2R_, 0);
+        this->get_parameter_or<uint8_t>("laser2G",laser2G_, 0);
+        this->get_parameter_or<uint8_t>("laser2B",laser2B_, 0);
         this->get_parameter_or<bool>("show2",show2_, false);
 
         
@@ -408,10 +408,10 @@ class scanMerger : public rclcpp::Node
     std::string topic1_, topic2_, cloudTopic_, cloudFrameId_;
     bool show1_, show2_;
     float laser1XOff_, laser1YOff_, laser1ZOff_, laser1Alpha_, laser1AngleMin_, laser1AngleMax_;
-    int laser1R_, laser1G_, laser1B_;
+    uint8_t laser1R_, laser1G_, laser1B_;
 
     float laser2XOff_, laser2YOff_, laser2ZOff_, laser2Alpha_, laser2AngleMin_, laser2AngleMax_;
-    int laser2R_, laser2G_, laser2B_;
+    uint8_t laser2R_, laser2G_, laser2B_;
 
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr sub1_;
     rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr sub2_;


### PR DESCRIPTION
the `.h` to `.hpp` is required by newer ROS versions, I found that by specifically setting defaults in `declare_parameter` this error could be avoided:
```bash
/opt/ros/humble/include/rclcpp/rclcpp/node.hpp:391:3: note: candidate: ‘const rclcpp::ParameterValue& rclcpp::Node::declare_parameter(const string&, rclcpp::ParameterType, const ParameterDescriptor&, bool)’
  391 |   declare_parameter(
      |   ^~~~~~~~~~~~~~~~~
/opt/ros/humble/include/rclcpp/rclcpp/node.hpp:391:3: note:   candidate expects 4 arguments, 1 provided
gmake[2]: *** [CMakeFiles/ros2_laser_scan_merger.dir/build.make:76: CMakeFiles/ros2_laser_scan_merger.dir/src/main.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/ros2_laser_scan_merger.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< ros2_laser_scan_merger [5.59s, exited with code 2]
```

 but needs more testing