### PR TITLE
Fix: Skip invalid or non-finite laser range values in point cloud generation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,8 +83,15 @@ private:
         {
           used_count_ = (int)laser1_->ranges.size() - 1 - count;
         }
-        float temp_x = laser1_->ranges[used_count_] * std::cos(i);
-        float temp_y = laser1_->ranges[used_count_] * std::sin(i);
+
+        float range = laser1_->ranges[used_count_];
+        if (!std::isfinite(range) || range <= 0.0f) {
+          count++;
+          continue;
+        }
+        float temp_x = range * std::cos(i);
+        float temp_y = range * std::sin(i);
+        
         pt.x =
             temp_x * std::cos(laser1Alpha_ * M_PI / 180) - temp_y * std::sin(laser1Alpha_ * M_PI / 180) + laser1XOff_;
         pt.y =
@@ -159,8 +166,14 @@ private:
           used_count_ = (int)laser2_->ranges.size() - 1 - count;
         }
 
-        float temp_x = laser2_->ranges[used_count_] * std::cos(i);
-        float temp_y = laser2_->ranges[used_count_] * std::sin(i);
+        float range = laser2_->ranges[used_count_];
+        if (!std::isfinite(range) || range <= 0.0f) {
+          count++;
+          continue;
+        }
+        float temp_x = range * std::cos(i);
+        float temp_y = range * std::sin(i);
+
         pt.x =
             temp_x * std::cos(laser2Alpha_ * M_PI / 180) - temp_y * std::sin(laser2Alpha_ * M_PI / 180) + laser2XOff_;
         pt.y =


### PR DESCRIPTION
While testing various lidars, we added simple error handling to effectively handle cases where there are problems with the lidar data. (RPLIDAR S2E, LDS-02)
This change adds a check in the update_point_cloud_rgb() function to skip inf, NaN, or non-positive range values from both laser1_ and laser2_, preventing invalid points in the generated PointCloud2 message. 